### PR TITLE
Fix Survival Arena & village loading bug on macOS

### DIFF
--- a/sessions.py
+++ b/sessions.py
@@ -71,6 +71,8 @@ def load_saved_villages():
             print("Ok.")
     # Saves in /saves
     for file in os.listdir(SAVES_DIR):
+        if file == ".DS_Store":
+            continue
         print(f" * Loading save at {file}... ", end='')
         try:
             save = json.load(open(os.path.join(SAVES_DIR, file)))

--- a/sessions.py
+++ b/sessions.py
@@ -88,8 +88,43 @@ def load_saved_villages():
         print(f"({map_name}) Ok.")
         __saves[str(USERID)] = save
         modified = migrate_loaded_save(save) # check save version for migration
-        if modified:
+        patched = patch_save(save)
+        if modified or patched:
             save_session(USERID)
+
+def patch_save(save: dict) -> bool:
+
+    # PATCH BEGIN: Survival Arena
+    modified = False
+    if("survivalVidaTimeStamp" not in save["privateState"]):
+        save["privateState"]["survivalVidaTimeStamp"] = []
+        modified = True
+    if("survivalVidasExtra" not in save["privateState"]):
+        save["privateState"]["survivalVidasExtra"] = 0
+        modified = True
+    if("survivalMaps" not in save["privateState"]):
+        save["privateState"]["survivalMaps"] = {
+            "100000035": {
+                "ts": 0,
+                "tp": 0
+            },
+            "100000036": {
+                "ts": 0,
+                "tp": 0
+            },
+            "100000037": {
+                "ts": 0,
+                "tp": 0
+            }
+        }
+        modified = True
+    # PATCH END: Survival Arena
+
+    if (modified):
+        print("   > patched")
+
+    return modified
+    
 
 # New village
 

--- a/sessions.py
+++ b/sessions.py
@@ -71,7 +71,7 @@ def load_saved_villages():
             print("Ok.")
     # Saves in /saves
     for file in os.listdir(SAVES_DIR):
-        if file == ".DS_Store":
+        if not file.endswith(".save.json"):
             continue
         print(f" * Loading save at {file}... ", end='')
         try:
@@ -90,42 +90,8 @@ def load_saved_villages():
         print(f"({map_name}) Ok.")
         __saves[str(USERID)] = save
         modified = migrate_loaded_save(save) # check save version for migration
-        patched = patch_save(save)
-        if modified or patched:
+        if modified:
             save_session(USERID)
-
-def patch_save(save: dict) -> bool:
-
-    # PATCH BEGIN: Survival Arena
-    modified = False
-    if("survivalVidaTimeStamp" not in save["privateState"]):
-        save["privateState"]["survivalVidaTimeStamp"] = []
-        modified = True
-    if("survivalVidasExtra" not in save["privateState"]):
-        save["privateState"]["survivalVidasExtra"] = 0
-        modified = True
-    if("survivalMaps" not in save["privateState"]):
-        save["privateState"]["survivalMaps"] = {
-            "100000035": {
-                "ts": 0,
-                "tp": 0
-            },
-            "100000036": {
-                "ts": 0,
-                "tp": 0
-            },
-            "100000037": {
-                "ts": 0,
-                "tp": 0
-            }
-        }
-        modified = True
-    # PATCH END: Survival Arena
-
-    if (modified):
-        print("   > patched")
-
-    return modified
     
 
 # New village

--- a/version.py
+++ b/version.py
@@ -41,6 +41,25 @@ def migrate_loaded_save(save: dict) -> bool:
     if save["version"] == "0.03a":
         if "pic" not in save["playerInfo"].keys():
             save["playerInfo"]["pic"] = ""
+        if("survivalVidaTimeStamp" not in save["privateState"]):
+            save["privateState"]["survivalVidaTimeStamp"] = []
+        if("survivalVidasExtra" not in save["privateState"]):
+            save["privateState"]["survivalVidasExtra"] = 0
+        if("survivalMaps" not in save["privateState"]):
+            save["privateState"]["survivalMaps"] = {
+                "100000035": {
+                    "ts": 0,
+                    "tp": 0
+                },
+                "100000036": {
+                    "ts": 0,
+                    "tp": 0
+                },
+                "100000037": {
+                    "ts": 0,
+                    "tp": 0
+                }
+            }
         # save["version"] = "0.04a"
         print("   > migrated to 0.04a")
 

--- a/villages/initial.json
+++ b/villages/initial.json
@@ -110,6 +110,22 @@
             "tournament": null
         },
         "arrayAnimals": {},
-        "strategy": 8
+        "strategy": 8,
+        "survivalMaps": {
+            "100000035": {
+                "ts": 0,
+                "tp": 0
+            },
+            "100000036": {
+                "ts": 0,
+                "tp": 0
+            },
+            "100000037": {
+                "ts": 0,
+                "tp": 0
+            }
+        },
+        "survivalVidaTimeStamp": [],
+        "survivalVidasExtra": 0,
     }
 }

--- a/villages/initial.json
+++ b/villages/initial.json
@@ -126,6 +126,6 @@
             }
         },
         "survivalVidaTimeStamp": [],
-        "survivalVidasExtra": 0,
+        "survivalVidasExtra": 0
     }
 }


### PR DESCRIPTION
* Added missing properties for Survival Arena to work. Old saves will be patched automatically.
*Only Darklands (100000036) map is available for now*
* .DS_Store (macOS system file) is ignored while loading villages

![image](https://github.com/user-attachments/assets/0e43737a-be90-4b2e-926e-68a02ef63787)
